### PR TITLE
Feature/v2 compatibility

### DIFF
--- a/lib/pokegem.rb
+++ b/lib/pokegem.rb
@@ -1,24 +1,116 @@
-require "pokegem/version"
+require 'pokegem/version'
 require 'typhoeus'
 require 'json'
 
 module Pokegem
   class << self
-    BASE_URL  = 'http://pokeapi.co/api/v1'
-    RESOURCES = %w(pokedex pokemon move ability type egg description sprite game)
+    BASE_URL  = 'http://pokeapi.co/api'
+    RESOURCES = {
+      'v1' => %w(
+        pokedex
+        pokemon
+        move
+        ability
+        type
+        egg
+        description
+        sprite
+        game
+      ),
+      'v2' => %w(
+        berry
+        berry-firmness
+        berry-flavor
+        contest-type
+        contest-effect
+        super-contest-effect
+        encounter-method
+        encounter-condition
+        encounter-condition-value
+        evolution-chain
+        evolution-trigger
+        generation
+        pokedex
+        version
+        version-group
+        item
+        item-attribute
+        item-category
+        item-fling-effect
+        item-pocket
+        machine
+        move
+        move-ailment
+        move-battle-style
+        move-category
+        move-damage-class
+        move-learn-method
+        move-target
+        location
+        location-area
+        pal-park-area
+        region
+        ability
+        characteristic
+        egg-group
+        gender
+        growth-rate
+        nature
+        pokeathlon-stat
+        pokemon
+        pokemon-color
+        pokemon-form
+        pokemon-habitat
+        pokemon-shape
+        pokemon-species
+        stat
+        type
+        language
+      )
+    }
+    API_VERSIONS = RESOURCES.keys
+    DEFAULT_API_VERSION = API_VERSIONS.last # Set last configured API as default
 
-    def init_hash; RESOURCES.reduce({}) { |h, r| h.merge! r => {} } end
-
-    def get(resource, n)
-      resource = resource.to_s
-      raise "Invalid resource, select from #{RESOURCES.join(', ')}" unless RESOURCES.include?(resource)
-      (@cache ||= init_hash)[resource][n] ||=
-        Typhoeus.get("#{BASE_URL}/#{resource}/#{n}", followlocation: true).options[:response_body]
+    def resources_hash
+      @resource_hash ||= RESOURCES.each { |k,v| RESOURCES[k] = Hash[v.map { |r| [r, {}] }] }
     end
 
-    def get_obj(resource, n)
+    def get(resource, n, **params)
       resource = resource.to_s
-      (@obj_cache ||= init_hash)[resource][n] ||= OpenStruct.new(JSON.parse(get(resource, n)))
+      api_version = (params[:api_version] || DEFAULT_API_VERSION).to_s
+
+      check_api_version!(api_version)
+      check_resource!(resource, api_version)
+
+      (@cache ||= resources_hash)[api_version][resource][n] ||=
+        Typhoeus.get("#{BASE_URL}/#{api_version}/#{resource}/#{n}", followlocation: true).options[:response_body]
     end
+
+    def get_obj(resource, n, **params)
+      resource = resource.to_s
+      api_version = (params[:api_version] || DEFAULT_API_VERSION).to_s
+
+      check_api_version!(api_version)
+      check_resource!(resource, api_version)
+
+      (@obj_cache ||= resources_hash)[api_version][resource][n] ||= OpenStruct.new(JSON.parse(get(resource, n, params)))
+    end
+
+    private
+      def is_api_version_valid?(api_version)
+        API_VERSIONS.include?(api_version)
+      end
+
+      def is_resource_valid_for_api?(resource, api_version)
+        resources_hash[api_version].keys.include?(resource)
+      end
+
+      def check_api_version!(api_version)
+        raise "Invalid API version, select from #{API_VERSIONS.join(', ')} (#{DEFAULT_API_VERSION} by default)" unless is_api_version_valid?(api_version)
+      end
+
+      def check_resource!(resource, api_version)
+        raise "Invalid resource, select from #{resources_hash[api_version].keys.join(', ')}" unless is_resource_valid_for_api?(resource, api_version)
+      end
   end
 end

--- a/lib/pokegem.rb
+++ b/lib/pokegem.rb
@@ -86,10 +86,6 @@ module Pokegem
     API_VERSIONS = RESOURCES.keys
     DEFAULT_API_VERSION = API_VERSIONS.last # Set last configured API as default
 
-    def resources_hash
-      @resource_hash ||= RESOURCES.each { |k,v| RESOURCES[k] = Hash[v.map { |r| [r, {}] }] }
-    end
-
     def get(resource, n = nil, **params)
       resource = resource.to_s
       api_version = (params[:api_version] || DEFAULT_API_VERSION).to_s
@@ -116,7 +112,7 @@ module Pokegem
       end
 
       def is_resource_valid_for_api?(resource, api_version)
-        resources_hash[api_version].keys.include?(resource)
+        RESOURCES[api_version].include?(resource)
       end
 
       def check_api_version!(api_version)
@@ -124,7 +120,7 @@ module Pokegem
       end
 
       def check_resource!(resource, api_version)
-        raise "Invalid resource, select from #{resources_hash[api_version].keys.join(', ')}" unless is_resource_valid_for_api?(resource, api_version)
+        raise "Invalid resource, select from #{RESOURCES[api_version].keys.join(', ')}" unless is_resource_valid_for_api?(resource, api_version)
       end
   end
 end

--- a/lib/pokegem/version.rb
+++ b/lib/pokegem/version.rb
@@ -1,3 +1,3 @@
 module Pokegem
-  VERSION = "0.0.3"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
Hi,

I've made some modifications into pokegem to be compatible with PokeApi V2 (https://pokeapi.co/docsv2/). These are modifications :
- Add PokeApi v2 resources
- Keep v1 compatibility and add possibility to choose between v1 and v2 into API calls (v2 is default if not specified)
- Use Typhoeus cache (OpenStruct object will still be created even for the same API call, but API call response will be cached at first time)
- Add possibility to send optionals parameters to API calls (examples are `limit` and `offset` parameters for v2 API)
- Add possibility to request resource without any id (or name). Example : `/v2/pokemons`

It wasn't possible to request API wihtout `id` ( /v2/pokemons ) and store this into cached hash because of parameters. We can't save `/v2/pokemons?limit=10` into cache and then ask for `/v2/pokemons` and just respond with 10 first pokemons. I would be happy to know your point of view about that.

Examples :

```
Pokegem.get_obj :language # API v2 by default
Pokegem.get :pokemon
Pokegem.get :pokemon, limit: 60, offset: 3
Pokegem.get :pokemon, 1, limit: 60 # Will just respond with first Pokemon, no matter limit option
Pokegem.get :pokemon, 1, api_version: :v1 # Will fetch first Pokemon using API v1
Pokegem.get :pokemon, 1, api_version: :v3 # Will throw error => No v3 version
Pokegem.get :item, 1, api_version: :v1 # Will throw error => Not supported by v1
```

Thank you.
